### PR TITLE
fix: use case-insensitive UUID comparison in onConnected

### DIFF
--- a/packages/core/src/models/device.model.ts
+++ b/packages/core/src/models/device.model.ts
@@ -898,7 +898,9 @@ export abstract class Device extends BaseModel implements IDevice {
     }
 
     for (const service of services) {
-      const matchingService = this.services.find((boardService) => boardService.uuid === service.uuid)
+      const matchingService = this.services.find(
+        (boardService) => boardService.uuid.toLowerCase() === service.uuid.toLowerCase(),
+      )
 
       if (matchingService) {
         // Android bug: Add a small delay before getting characteristics
@@ -907,11 +909,15 @@ export abstract class Device extends BaseModel implements IDevice {
         const characteristics = await service.getCharacteristics()
 
         for (const characteristic of matchingService.characteristics) {
-          const matchingCharacteristic = characteristics.find((char) => char.uuid === characteristic.uuid)
+          const matchingCharacteristic = characteristics.find(
+            (char) => char.uuid.toLowerCase() === characteristic.uuid.toLowerCase(),
+          )
 
           if (matchingCharacteristic) {
             // Find the corresponding characteristic descriptor in the service's characteristics array
-            const descriptor = matchingService.characteristics.find((char) => char.uuid === matchingCharacteristic.uuid)
+            const descriptor = matchingService.characteristics.find(
+              (char) => char.uuid.toLowerCase() === matchingCharacteristic.uuid.toLowerCase(),
+            )
             if (descriptor) {
               // Assign the actual Bluetooth characteristic object to the descriptor so it can be used later
               descriptor.characteristic = matchingCharacteristic


### PR DESCRIPTION
## Problem

Some browsers (notably Bluefy on iOS/WKWebView) return UUIDs in uppercase from the Web Bluetooth API, while the library defines them in lowercase. This causes the `===` comparison in `onConnected` to fail, preventing characteristics from being matched and assigned.

The error manifests as:
```
Characteristic tx not found in service progressor
```

## Solution

Normalize both sides to lowercase before comparing using `.toLowerCase()`. This is safe since UUIDs are case-insensitive by definition (RFC 4122).

## Changes

Three UUID comparisons in `packages/core/src/models/device.model.ts`:
- Line 901: service UUID matching
- Line 910: characteristic UUID matching  
- Line 914: descriptor UUID matching

## Testing

Tested with Tindeq Progressor on:
- Desktop Chrome (works before and after)
- iOS Bluefy (broken before, works after)