### PR TITLE
fix(react-native): pass allowDuplicates to the WH-C06 scan so iOS keeps receiving weight updates

### DIFF
--- a/.changeset/whc06-ios-allow-duplicates.md
+++ b/.changeset/whc06-ios-allow-duplicates.md
@@ -1,0 +1,6 @@
+---
+"@hangtime/grip-connect-react-native": patch
+---
+
+Fix WH-C06 weight stream freezing on iOS: pass `allowDuplicates: true` to `startDeviceScan`, so CoreBluetooth reports
+every advertisement packet from the broadcast-only scale (matching the Capacitor model's `requestLEScan` options).

--- a/packages/react-native/src/models/device/wh-c06.model.ts
+++ b/packages/react-native/src/models/device/wh-c06.model.ts
@@ -42,53 +42,61 @@ export class WHC06 extends WHC06Base {
     onError: (error: Error) => void = (error) => console.error(error),
   ): Promise<void> => {
     try {
-      this.manager.startDeviceScan(null, { scanMode: 2, callbackType: 1 }, (error, scannedDevice) => {
-        if (error) {
-          onError(error)
-          return
-        }
+      // allowDuplicates is required on iOS: without it CoreBluetooth coalesces
+      // repeated advertisements, and since the WH-C06 is broadcast-only (weight
+      // lives in manufacturerData), the stream freezes after the first packet.
+      // scanMode/callbackType are Android-only; each platform ignores the other's keys.
+      this.manager.startDeviceScan(
+        null,
+        { allowDuplicates: true, scanMode: 2, callbackType: 1 },
+        (error, scannedDevice) => {
+          if (error) {
+            onError(error)
+            return
+          }
 
-        if (scannedDevice && (scannedDevice.localName === "IF_B7" || scannedDevice.name === "IF_B7")) {
-          // Update timestamp
-          this.updateTimestamp()
+          if (scannedDevice && (scannedDevice.localName === "IF_B7" || scannedDevice.name === "IF_B7")) {
+            // Update timestamp
+            this.updateTimestamp()
 
-          // Device has no services / characteristics, so we directly call onSuccess
-          onSuccess()
+            // Device has no services / characteristics, so we directly call onSuccess
+            onSuccess()
 
-          const manufacturerData = scannedDevice.manufacturerData
+            const manufacturerData = scannedDevice.manufacturerData
 
-          // Handle received data
-          this.currentSamplesPerPacket = 1
-          this.recordPacketReceived()
-          const receivedTime: number = Date.now()
-          const receivedData = this.parseWeightData(manufacturerData)
+            // Handle received data
+            this.currentSamplesPerPacket = 1
+            this.recordPacketReceived()
+            const receivedTime: number = Date.now()
+            const receivedData = this.parseWeightData(manufacturerData)
 
-          // Tare correction
-          const numericData = receivedData - this.applyTare(receivedData) * -1
-          const currentMassTotal = Math.max(-1000, numericData)
+            // Tare correction
+            const numericData = receivedData - this.applyTare(receivedData) * -1
+            const currentMassTotal = Math.max(-1000, numericData)
 
-          // Update session stats before building packet
-          this.peak = Math.max(this.peak, numericData)
-          this.min = Math.min(this.min, Math.max(-1000, numericData))
-          this.sum += currentMassTotal
-          this.dataPointCount++
-          this.mean = this.sum / this.dataPointCount
+            // Update session stats before building packet
+            this.peak = Math.max(this.peak, numericData)
+            this.min = Math.min(this.min, Math.max(-1000, numericData))
+            this.sum += currentMassTotal
+            this.dataPointCount++
+            this.mean = this.sum / this.dataPointCount
 
-          // Add data to downloadable Array
-          this.downloadPackets.push(
-            this.buildDownloadPacket(currentMassTotal, [numericData], {
-              timestamp: receivedTime,
-              sampleIndex: this.dataPointCount,
-            }),
-          )
+            // Add data to downloadable Array
+            this.downloadPackets.push(
+              this.buildDownloadPacket(currentMassTotal, [numericData], {
+                timestamp: receivedTime,
+                sampleIndex: this.dataPointCount,
+              }),
+            )
 
-          // Check if device is being used
-          this.activityCheck(numericData)
+            // Check if device is being used
+            this.activityCheck(numericData)
 
-          // Notify with weight data
-          this.notifyCallback(this.buildForceMeasurement(currentMassTotal))
-        }
-      })
+            // Notify with weight data
+            this.notifyCallback(this.buildForceMeasurement(currentMassTotal))
+          }
+        },
+      )
     } catch (error) {
       onError(error as Error)
     }


### PR DESCRIPTION
Fixes #15.

## Problem

The WH-C06 is broadcast-only: the weight lives in advertisement `manufacturerData`, so repeated advertisements are the only data channel. The React Native model starts the scan with Android-only options (`scanMode`, `callbackType`) and no `allowDuplicates`. On iOS, CoreBluetooth reports each peripheral only once per scan by default (`CBCentralManagerScanOptionAllowDuplicatesKey` = false), so the weight stream freezes after the first packet.

## Fix

Add `allowDuplicates: true` to the `startDeviceScan` options — mirroring what the Capacitor model already does for `requestLEScan`. The Android-only keys are untouched; each platform ignores the other's keys, so Android behavior is unchanged.

The diff looks larger than it is: `oxfmt` reflowed the now-longer `startDeviceScan` call into the multi-line form. The semantic change is one option key plus a comment. A patch changeset for `@hangtime/grip-connect-react-native` is included.

## Testing

- `npm run build:react-native` (tsc) passes; `oxlint`/`oxfmt` clean; `allowDuplicates` verified present in `react-native-ble-plx` `ScanOptions`.
- Hardware validation on a physical WH-C06 + iPhone is scheduled on our side this week — happy to report the measured advertisement rate here once done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)